### PR TITLE
Fix missing return type annotation

### DIFF
--- a/scripts/template_update.py
+++ b/scripts/template_update.py
@@ -105,7 +105,7 @@ def init(languages: set[str], dry_run: bool) -> None:
     delete_files_and_folder(files_to_delete, dry_run)
 
 
-def remove_file(filepath: str):
+def remove_file(filepath: str) -> None:
     try:
         os.remove(filepath)
     except FileNotFoundError:


### PR DESCRIPTION
<!--
* Keep your PR:s small and focused.
* The PR title is what ends up in the changelog, so make it descriptive!
* If applicable, add a screenshot or gif.
* Do NOT open PR:s from your `main` branch, as that makes it hard for maintainers to test and add commits to your PR.
* Remember to run `cargo fmt` and `cargo clippy`.
* Open the PR as a draft until you have self-reviewed it and it passes CI.
* When you have addressed a PR comment, mark it as resolved.

Please be patient!
-->

This PR fixes a py-lint error where a function was missing its return type annotation.