### PR TITLE
Switch .vscode extension to dependi and fix rust checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,68 +34,42 @@ jobs:
           version: 1.0
           execute_install_scripts: true
 
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.0
+
       - name: Set up cargo cache
         uses: Swatinem/rust-cache@v2
 
       - name: Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: pixi run cargo fmt --all -- --check
 
       - name: check --all-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-features --all-targets
+        run: pixi run cargo check --all-features --all-targets
 
       - name: check default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all-targets
+        run: pixi run cargo check --all-targets
 
       - name: check --no-default-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --no-default-features --lib --all-targets
+        run: pixi run cargo check --no-default-features --all-targets
 
       - name: Test doc-tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --doc --all-features
+        run: pixi run cargo test --doc --all-features
 
       - name: cargo doc --lib
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --lib --no-deps --all-features
+        run: pixi run cargo doc --lib --no-deps --all-features
 
       - name: cargo doc --document-private-items
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --document-private-items --no-deps --all-features
+        run: pixi run cargo doc --document-private-items --no-deps --all-features
 
       - name: Build tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features --no-run
+        run: pixi run cargo build --tests --all-features
 
       - name: Run test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
+        run: pixi run cargo test --all-features
 
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
+        run: pixi run cargo clippy --all-targets --all-features -- -D warnings
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,12 +22,12 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: default
-          toolchain: 1.80.0
+          toolchain: 1.81.0
           override: true
 
       - name: Install packages (Linux)
         if: runner.os == 'Linux' && false # TODO: enable if eframe is part of the project, otherwise remove
-        uses: awalsh128/cache-apt-pkgs-action@v1.3.0
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
           # some deps used by eframe, if that is part of the project
           packages: libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev # libgtk-3-dev is used by rfd

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,8 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "charliermarsh.ruff",
+    "esbenp.prettier-vscode",
+    "fill-labs.dependi",
     "gaborv.flatbuffers",
     "github.vscode-github-actions",
     "josetr.cmake-language-support-vscode",
@@ -13,7 +15,6 @@
     "ms-vsliveshare.vsliveshare",
     "polymeilex.wgsl",
     "rust-lang.rust-analyzer",
-    "serayuzgur.crates",
     "streetsidesoftware.code-spell-checker",
     "tamasfe.even-better-toml",
     "vadimcn.vscode-lldb",
@@ -21,6 +22,5 @@
     "webfreak.debug",
     "xaver.clang-format", // C++ formatter
     "zxh404.vscode-proto3",
-    "esbenp.prettier-vscode"
   ]
 }


### PR DESCRIPTION
The `serayuzgur.crates` extension is deprecated and causes a warning in vs code.
