### PR TITLE
Migrate vscode settings to native Ruff language server

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,12 +38,7 @@
     "cmake.buildDirectory": "${workspaceRoot}/build/debug",
     "cmake.generator": "Ninja", // Use Ninja, just like we do in our just/pixi command.
     "rust-analyzer.showUnlinkedFileNotification": false,
-    "ruff.format.args": [
-        "--config=pyproject.toml"
-    ],
-    "ruff.lint.args": [
-        "--config=pyproject.toml"
-    ],
+    "ruff.configuration": "pyproject.toml",
     "prettier.requireConfig": true,
     "prettier.configPath": ".prettierrc.toml",
     "[python]": {


### PR DESCRIPTION
### What

This changes the `.vscode/settings.json` file to use the native Ruff server instead of the old `ruff-lsp` extension settings, since the language server is now stable and `ruff-lsp` is deprecated.

It also gets rid of the annoying vscode pop up:

<img width="488" alt="image" src="https://github.com/user-attachments/assets/43368275-f5a4-470a-bc09-1c96e0ac0489" />

