### PR TITLE
Fix Python Test Name Copy Paste Typo

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [ opened, synchronize ]
 
-name: C++
+name: Python
 
 jobs:
   python-check:


### PR DESCRIPTION
This fixes the workflow name in the template.

See previous job https://github.com/rerun-io/rerun_template/actions/runs/15187142040/job/42710204575 where the job is named python but under the C++ workflow.
